### PR TITLE
Survey screen

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -173,6 +173,8 @@ class SurveyResponse {
 }
 ```
 
+The `SurveyQuestion` object is part of `sites.json`, since it's configured only once at source. However survey questions can be different per site. The `SurveyResponse` is captured once per pipeline. So it's part of the `CapturedSession` data structure. 
+
 ## Location logic 
 
 See [motion doc](./motion.md). In summary we use the `geolocator` plugin to do the following 

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -1,0 +1,7 @@
+# Survey capture 
+
+* The survey support architecture is very simple. 
+* For each question, there are 2 types: `text` and `mcq`
+* For `text` we use a `TextField`, for `mcq` we use a `DropDownButton`
+* Each question in `sites.json` has a `questionId`, and this is used to track responses in a Map
+* When the user hits submit, these fields are transferred to a `CapturedSession` object and written to a file 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -7,13 +7,43 @@
 
 3. Scaling images (see [docs/aspectratio](./aspectratio.md))
 
-4. Refactor routes into named routes, ideally we would have centralized routing and invoke the pipeline like so
+4. Don't block home screen on prefetching - users in the field must be allowed to run multiple pipelines. Currently we try to re-fetch in home screens init. 
+
+
+5. Auth 
+
+6. First image is without ghost. The how do users set a ghost? Avoid confusion, just don't set one at first. 
+
+### Tech Debt
+
+1. Refactor routes into named routes, ideally we would have centralized routing and invoke the pipeline like so
 ```
 Navigator.of(context).pushReplacementNamed(
   '/capture_landscape',
   arguments: ConfirmScreenArgs(...),
 );
 ```
+2. Extract orientation logic into an OrientationService (see [code.md reentry](code.md)).
+3. Find a cleaner way to manage global state instead of threading through the pipelien 
+	- Current method only works for few screens
+	- A better alternative is to use a `UserSession` singleton
+```
+class UserSession {
+  static String name = '';
+  static String email = '';
+  static String org = '';
+
+  static void set({required String n, required String e, required String o}) {
+    name = n;
+    email = e;
+    org = o;
+  }
+}
+UserSession.set(name: name, email: email, org: org);
+final org = UserSession.org;
+```
+
+
 
 ### Thought issues 
 

--- a/fomomon/lib/models/captured_session.dart
+++ b/fomomon/lib/models/captured_session.dart
@@ -1,20 +1,4 @@
-import 'dart:convert';
-
-class SurveyResponse {
-  final String questionId;
-  final String answer;
-
-  SurveyResponse({required this.questionId, required this.answer});
-
-  Map<String, dynamic> toJson() => {'questionId': questionId, 'answer': answer};
-
-  factory SurveyResponse.fromJson(Map<String, dynamic> json) {
-    return SurveyResponse(
-      questionId: json['questionId'],
-      answer: json['answer'],
-    );
-  }
-}
+import 'survey_response.dart';
 
 class CapturedSession {
   final String sessionId; // e.g. userId_timestamp

--- a/fomomon/lib/models/confirm_screen_args.dart
+++ b/fomomon/lib/models/confirm_screen_args.dart
@@ -7,6 +7,9 @@ class ConfirmScreenArgs {
   final String captureMode; // 'portrait' or 'landscape'
   final Site site;
   final String userId;
+  final String name;
+  final String email;
+  final String org;
 
   ConfirmScreenArgs({
     this.portraitImagePath,
@@ -14,5 +17,8 @@ class ConfirmScreenArgs {
     required this.captureMode,
     required this.site,
     required this.userId,
+    required this.name,
+    required this.email,
+    required this.org,
   });
 }

--- a/fomomon/lib/models/site.dart
+++ b/fomomon/lib/models/site.dart
@@ -3,6 +3,8 @@
 /// Data model representing a field site with lat/lng and reference info
 /// Mirrors the structure of entries in `sites.json`
 
+import 'survey_question.dart';
+
 class Site {
   final String id;
   final double lat;
@@ -12,6 +14,7 @@ class Site {
   String? localPortraitPath;
   String? localLandscapePath;
   final String bucketRoot;
+  final List<SurveyQuestion> surveyQuestions;
 
   Site({
     required this.id,
@@ -22,6 +25,7 @@ class Site {
     this.localPortraitPath,
     this.localLandscapePath,
     required this.bucketRoot,
+    required this.surveyQuestions,
   });
 
   factory Site.fromJson(Map<String, dynamic> json, String bucketRoot) {
@@ -32,6 +36,12 @@ class Site {
       referencePortrait: json['reference_portrait'],
       referenceLandscape: json['reference_landscape'],
       bucketRoot: bucketRoot,
+      surveyQuestions:
+          (json['survey'] as List<dynamic>)
+              .map((q) => SurveyQuestion.fromJson(q))
+              .toList(),
     );
   }
+
+  // Site does not have a toJson because we never write to it.
 }

--- a/fomomon/lib/models/survey_question.dart
+++ b/fomomon/lib/models/survey_question.dart
@@ -1,0 +1,31 @@
+class SurveyQuestion {
+  final String id;
+  final String question;
+  final String type; // 'text' or 'mcq'
+  final List<String>? options;
+
+  SurveyQuestion({
+    required this.id,
+    required this.question,
+    required this.type,
+    this.options,
+  });
+
+  factory SurveyQuestion.fromJson(Map<String, dynamic> json) {
+    return SurveyQuestion(
+      id: json['id'],
+      question: json['question'],
+      type: json['type'],
+      options: (json['options'] as List?)?.map((e) => e.toString()).toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'question': question,
+      'type': type,
+      if (options != null) 'options': options,
+    };
+  }
+}

--- a/fomomon/lib/models/survey_response.dart
+++ b/fomomon/lib/models/survey_response.dart
@@ -1,0 +1,17 @@
+class SurveyResponse {
+  final String questionId;
+  final String answer;
+
+  SurveyResponse({required this.questionId, required this.answer});
+
+  factory SurveyResponse.fromJson(Map<String, dynamic> json) {
+    return SurveyResponse(
+      questionId: json['questionId'],
+      answer: json['answer'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {'questionId': questionId, 'answer': answer};
+  }
+}

--- a/fomomon/lib/screens/capture_screen.dart
+++ b/fomomon/lib/screens/capture_screen.dart
@@ -24,6 +24,9 @@ class CaptureScreen extends StatefulWidget {
 
   final String? landscapeImagePath;
   final String? portraitImagePath;
+  final String name;
+  final String email;
+  final String org;
 
   const CaptureScreen({
     super.key,
@@ -32,6 +35,9 @@ class CaptureScreen extends StatefulWidget {
     required this.userId,
     this.landscapeImagePath,
     this.portraitImagePath,
+    required this.name,
+    required this.email,
+    required this.org,
   });
 
   @override
@@ -105,6 +111,9 @@ class _CaptureScreenState extends State<CaptureScreen> {
                   captureMode: widget.captureMode,
                   site: widget.site,
                   userId: widget.userId,
+                  name: widget.name,
+                  email: widget.email,
+                  org: widget.org,
                 ),
               ),
         ),

--- a/fomomon/lib/screens/confirm_screen.dart
+++ b/fomomon/lib/screens/confirm_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import '../services/local_image_storage.dart';
 import '../models/confirm_screen_args.dart';
 import '../screens/capture_screen.dart';
+import '../screens/survey_screen.dart';
 
 class ConfirmScreen extends StatefulWidget {
   final ConfirmScreenArgs args;
@@ -49,7 +50,7 @@ class _ConfirmScreenState extends State<ConfirmScreen> {
                 icon: const Icon(Icons.close),
                 label: const Text('Retake'),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color.fromARGB(144, 54, 22, 19),
+                  backgroundColor: const Color.fromARGB(229, 54, 22, 19),
                   foregroundColor: Colors.red,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(40),
@@ -71,7 +72,7 @@ class _ConfirmScreenState extends State<ConfirmScreen> {
                 icon: const Icon(Icons.check),
                 label: const Text('Use Photo'),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color.fromARGB(144, 22, 54, 19),
+                  backgroundColor: const Color.fromARGB(229, 22, 54, 19),
                   foregroundColor: Colors.green,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(40),
@@ -127,9 +128,6 @@ class _ConfirmScreenState extends State<ConfirmScreen> {
     if (!context.mounted) return;
 
     if (args.captureMode == 'portrait') {
-      print(
-        '============================Launching next capture for landscape, portraitImagePath: ${savedPath}, landscapeImagePath: ${args.landscapeImagePath}',
-      );
       // Launch next capture
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(
@@ -139,23 +137,28 @@ class _ConfirmScreenState extends State<ConfirmScreen> {
                 captureMode: 'landscape',
                 site: args.site,
                 userId: args.userId,
+                name: args.name,
+                email: args.email,
+                org: args.org,
               ),
         ),
       );
     } else {
-      print(
-        '============================Launching survey, landscapeImagePath: ${savedPath}, portraitImagePath: ${args.portraitImagePath}',
-      );
       // Launch survey
-      Navigator.of(context).pushReplacementNamed(
-        '/survey',
-        arguments: {
-          'userId': args.userId,
-          'site': args.site,
-          'portraitImagePath': args.portraitImagePath!,
-          'landscapeImagePath': savedPath,
-          'timestamp': timestamp.toIso8601String(),
-        },
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder:
+              (_) => SurveyScreen(
+                userId: args.userId,
+                site: args.site,
+                portraitImagePath: args.portraitImagePath!,
+                landscapeImagePath: savedPath,
+                timestamp: timestamp,
+                name: args.name,
+                email: args.email,
+                org: args.org,
+              ),
+        ),
       );
     }
   }


### PR DESCRIPTION
General survey outline (see `docs/surveys.md`):

* The survey support architecture is very simple.
* For each question, there are 2 types: `text` and `mcq`
* For `text` we use a `TextField`, for `mcq` we use a `DropDownButton`
* Each question in `sites.json` has a `questionId`, and this is used to track responses in a Map
* When the user hits submit, these fields are transferred to a `CapturedSession` object and written to a file

Apart from the survey this pr also does:

1. Question/answer models
2. Survey screen that saves sessions via local storage
3. Return to Home screen using the threaded through args