### PR TITLE
Ghost fetching, gps accuracy and home screen ux

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -34,12 +34,11 @@
 1. LoginScreen
 2. SitePrefetchScreen
 3. HomeScreen
+	3.a. Upload_feedback_panel
+	3.b. GPS_feedback_panel
 4. CaptureScreen
 5. ConfirmScreen
 6. SurveyScreen
-7. ReviewScreen
-8. GalleryScreen
-9. UploadScreen
 
 
 ## Data Structures and storages 
@@ -114,7 +113,9 @@ s3://bucket/org/
 │   ├── {userId}_{timestamp}_portrait.jpg
 │   └── ...
 ├── db/
-│   └── {userId}_{timestamp}.json
+│   └── {timestamp}.json
+├── sessions/
+│   ├── {userId}_{timestamp}.json
 ```
 * There is only one sites file per all users in an org, and it captures all sites info. 
 * Each db file is a batch of session data (though it could be the output of a single pipeline as well) captured on one phone, covering one or more sites, and one single upload action. 
@@ -127,6 +128,10 @@ documents/
 │   │   └── {userId}_{timestamp}_landscape.jpg
 ├── sessions/
 │   ├── {userId}_{timestamp}.json
+├── ghosts/
+│   ├── site_001/
+│   │   ├── <original_file_name>.jpg
+│   │   └── <original_file_name>.jpg
 ```
 
 Where `documents` is what's returned by `getApplicationDocumentsDirectory`.
@@ -182,7 +187,6 @@ See [motion doc](./motion.md). In summary we use the `geolocator` plugin to do t
 2. Compare distance with every site in array
 3. Show golden ring around the "+" button within 10m 
 
-
 ## Capture interface 
 
 3 aspects of this
@@ -192,22 +196,6 @@ See [motion doc](./motion.md). In summary we use the `geolocator` plugin to do t
 
 We do this in both portrait and landscape mode. 
 There are some tricky aspects of how we pipeline the capture interfaces with the confirmation screens. See [code doc](./code.md).
-
-## Client side syncing 
-
-We have decided to sync at 2 places: 
-
-1. Post login, through an explicity `site_prefetch_screen`. This is so the user doesn't immediately plop into a pipeline and end up with an error saying "ghost image unavailable". 
-2. In the init of every home screen.
-
-2 is triggered everytime the user finishes the pipeline. But 2 is a "best effort" sync, meaning if there is no network, we ignore and carry on so the user can save multiple pipeliens back to back. 
-
-Simple fetch every 24h of sites.json and users.json is option 2. 
-
-## Survey UI 
-
-Simple list of text, radio buttons depending on `SurveyQuestion.type`
-Final submit button closes and saves teh session 
 
 ## Multi-org/user support 
 
@@ -229,23 +217,27 @@ In the login flow we ask for: login name or email + org code and reconstruct usi
 ```
 bucketRoot = "https://fomomon-data.s3.amazonaws.com/$org/"
 ```
+## Client side syncing 
+
+We have decided to sync at 2 places: 
+
+1. Post login, through an explicity `site_prefetch_screen`. This is so the user doesn't immediately plop into a pipeline and end up with an error saying "ghost image unavailable". 
+2. In the init of every home screen.
+
+2 is triggered everytime the user finishes the pipeline. But 2 is a "best effort" sync, meaning if there is no network, we ignore and carry on so the user can save multiple pipeliens back to back. 
+
+Simple fetch every 24h of sites.json and users.json is option 2. 
+
+### Uploads 
+
+1. Upload images 
+2. Replace local paths in session metadata with s3 urls
+3. Upload all session.jsons into the `sessions/` directory
+
+See [docs/upload](./upload.md) for detaials. 
 
 ### App local storage management 
 
 We use services for the local storage. 
 
-### S3 storage management 
-
-1. Upload images 
-2. Replace local paths in session metadata with s3 urls
-3. Upload all session.jsons into the `db/` directory
-
-## Uploads and Sync 
-
-* Atomic uploads 
-	- Store each session locally. 
-	- Only delete sessions after successful upload (all images + JSON).
-	- No need for an uploaded flag.
-	- UI can just show all current local sessions. If it’s not there, it’s
-	  uploaded. If it’s there, it’s pending.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -14,6 +14,10 @@
 
 6. First image is without ghost. The how do users set a ghost? Avoid confusion, just don't set one at first. 
 
+7. Metrics and consolidated logging 
+
+8. URLs and repeatability: if a session or image is uploaded to some url, and there is an app crash before we can mark the session as uploaded, will the next url created for the same session be different or the same? do we need to garbage collect stray images/sessions in s3? 
+
 ### Tech Debt
 
 1. Refactor routes into named routes, ideally we would have centralized routing and invoke the pipeline like so
@@ -42,7 +46,7 @@ class UserSession {
 UserSession.set(name: name, email: email, org: org);
 final org = UserSession.org;
 ```
-
+4. Clean up HomeScreen. It's currently got too many stacks in its build method. 
 
 
 ### Thought issues 

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -1,0 +1,30 @@
+# Uploading sessions 
+
+1. Read all local and un uploaded CapturedSession files 
+2. For each session
+- upload images: 
+	`portraitImagePath` -> `site_id/{userId}_{timestamp}_portrait.jpg`
+	`landscapeImagePath` -> `site_id/{userId}_{timestamp}_landscape.jpg`
+- Replace paths in the CapturedSession objects with the S3 URLs (this happens in-memory)
+3. Upload the modified session JSON into `sessions/{userId}_{timestamp}.json`
+4. Mark the local sessions as "uploaded" 
+
+The decision to upload sessions separately was made to keep things simple.
+
+1. Avoids s3 write conflicts 
+2. Uploads from the phone are atomic and recoverable (i.e recovery means keeping the session files on the phone, and simply re-uploading them)
+3. Merges of all users' session files into one checkpoint/db file can be done via lambda or script
+
+Errors in uploading are managed by simply _not_ writing the "uplaoded" bit so the session manager returns the session the next time around. This is also why we retain the local-path-sessions on disk instead of overwriting it with the modified with-url sessions. 
+
+## Merging sessions into a db	
+
+TBD
+
+## Moving the db file into an actual db
+
+TBD
+
+## DB backups 
+
+TBD

--- a/docs/ux.md
+++ b/docs/ux.md
@@ -1,0 +1,34 @@
+# FOMO App ux mods 
+
+Focus on repeatability and ease for a 20 year timeline. 
+
+## Pipeline 
+
+1. Pipeline with stages to reduce choice/error
+2. Take both 
+
+## Ghost images 
+
+1. Rule of Thirds Overlay
+2. Ghost Alignment Feedback
+3. Aspect Ratio Tuning (?)
+4. Portrait Mode Support (currently same image used in both) 
+5. Minimize Camera UI Clutter
+6. Camera Button Optimization (save/swap is confusing) 
+	
+## Location 
+
+1. Map vs proximity
+	- "you're within 5m of the station" 
+	- feedback when user has reached station stone
+2. Bearing/Compass Integration
+	- compass overlay showing direction to the station (?)
+	- Display “go NW” hints: which way to look? 
+3. Error and manual filling of gps coords? 
+
+
+## Planned 
+
+1. Station creation 
+2. Data ingestion 
+

--- a/examples/sites.json
+++ b/examples/sites.json
@@ -8,8 +8,8 @@
         "lng": 77.638222
       },
       "creation_timestamp": "2025-07-14T18:20:48.951059Z",
-      "reference_portrait": "test_site_001/portrait_ref.png",
-      "reference_landscape": "test_site_001/landscape_ref.png",
+      "reference_portrait": "test_site_001/srini_portrait.jpg",
+      "reference_landscape": "test_site_001/2022-09-DSCN7782_landscape.jpg",
       "survey": [
         {
           "id": "q1",
@@ -34,8 +34,8 @@
         "lng": 77.63939715713012
       },
       "creation_timestamp": "2025-07-14T18:20:48.951059Z",
-      "reference_portrait": "test_site_001/portrait_ref.png",
-      "reference_landscape": "test_site_001/landscape_ref.png",
+      "reference_portrait": "test_site_001/srini_portrait.jpg",
+      "reference_landscape": "test_site_001/2022-09-DSCN7782_landscape.jpg",
       "survey": [
         {
           "id": "q1",
@@ -60,8 +60,8 @@
         "lng": 77.627378
       },
       "creation_timestamp": "2025-07-14T18:20:48.951059Z",
-      "reference_portrait": "test_site_001/portrait_ref.png",
-      "reference_landscape": "test_site_001/landscape_ref.png",
+      "reference_portrait": "test_site_001/srini_portrait.jpg",
+      "reference_landscape": "test_site_001/2022-09-DSCN7782_landscape.jpg",
       "survey": [
         {
           "id": "q1",

--- a/fomomon/lib/screens/survey_screen.dart
+++ b/fomomon/lib/screens/survey_screen.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import '../models/site.dart';
+import '../models/survey_response.dart';
+import '../models/captured_session.dart';
+import '../services/local_session_storage.dart';
+import '../models/survey_question.dart';
+import '../screens/home_screen.dart';
+
+class SurveyScreen extends StatefulWidget {
+  final String userId;
+  final Site site;
+  final String portraitImagePath;
+  final String landscapeImagePath;
+  final DateTime timestamp;
+  final String name;
+  final String email;
+  final String org;
+
+  const SurveyScreen({
+    super.key,
+    required this.userId,
+    required this.site,
+    required this.portraitImagePath,
+    required this.landscapeImagePath,
+    required this.timestamp,
+    required this.name,
+    required this.email,
+    required this.org,
+  });
+
+  @override
+  State<SurveyScreen> createState() => _SurveyScreenState();
+}
+
+class _SurveyScreenState extends State<SurveyScreen> {
+  final Map<String, String> _answers = {};
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Survey')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: ListView(
+          children: [
+            ...widget.site.surveyQuestions.map(_buildQuestion),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _submitSurvey,
+              child: const Text('Submit Survey'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQuestion(SurveyQuestion question) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            question.question,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          if (question.type == 'text')
+            _buildTextField(question)
+          else if (question.type == 'mcq')
+            _buildDropdown(question),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTextField(SurveyQuestion question) {
+    // Update the answer map every time the user types a letter.
+    return TextField(
+      decoration: const InputDecoration(border: OutlineInputBorder()),
+      onChanged: (value) => _answers[question.id] = value,
+    );
+  }
+
+  Widget _buildDropdown(SurveyQuestion question) {
+    final options = question.options ?? [];
+
+    return DropdownButtonFormField<String>(
+      value: _answers[question.id],
+      items:
+          options
+              .map((opt) => DropdownMenuItem(value: opt, child: Text(opt)))
+              .toList(),
+      onChanged: (value) {
+        if (value != null) setState(() => _answers[question.id] = value);
+      },
+      decoration: const InputDecoration(border: OutlineInputBorder()),
+    );
+  }
+
+  void _submitSurvey() async {
+    final responses =
+        _answers.entries
+            .map((e) => SurveyResponse(questionId: e.key, answer: e.value))
+            .toList();
+
+    final session = CapturedSession(
+      sessionId: '${widget.userId}_${widget.timestamp.toIso8601String()}',
+      siteId: widget.site.id,
+      latitude: widget.site.lat,
+      longitude: widget.site.lng,
+      portraitImagePath: widget.portraitImagePath,
+      landscapeImagePath: widget.landscapeImagePath,
+      timestamp: widget.timestamp,
+      responses: responses,
+      userId: widget.userId,
+    );
+
+    await LocalSessionStorage.saveSession(session);
+    if (!mounted) return;
+
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(
+        builder:
+            (_) => HomeScreen(
+              name: widget.name,
+              email: widget.email,
+              org: widget.org,
+            ),
+      ),
+      (route) => false,
+    );
+  }
+}

--- a/fomomon/lib/widgets/gps_feedback_panel.dart
+++ b/fomomon/lib/widgets/gps_feedback_panel.dart
@@ -63,7 +63,6 @@ class GpsFeedbackPanel extends StatelessWidget {
     if (user == null) return [];
 
     return sites.map((site) {
-      print("gps_panel: building dot for site: ${site.id}");
       final dx = Geolocator.distanceBetween(
         user!.latitude,
         user!.longitude,
@@ -79,6 +78,9 @@ class GpsFeedbackPanel extends StatelessWidget {
 
       final left = 90 + dx * (site.lng > user!.longitude ? 1 : -1) * 0.5;
       final top = 90 + dy * (site.lat > user!.latitude ? 1 : -1) * 0.5;
+      print(
+        "gps_panel: site: ${site.id}, dx: $dx, dy: $dy, left: $left, top: $top, user: ${user!.latitude}, ${user!.longitude}, site: ${site.lat}, ${site.lng}, user: ${user!.latitude}, ${user!.longitude}",
+      );
 
       // The clamp() is used to ensure that the left and top values are within
       // bounds 0-180 pixels. This gives us a range of 360m for sites. Far away

--- a/fomomon/lib/widgets/upload_dial_widget.dart
+++ b/fomomon/lib/widgets/upload_dial_widget.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import '../services/local_session_storage.dart';
+
+class UploadDialWidget extends StatefulWidget {
+  const UploadDialWidget({super.key});
+
+  @override
+  State<UploadDialWidget> createState() => _UploadDialWidgetState();
+}
+
+class _UploadDialWidgetState extends State<UploadDialWidget> {
+  int uploaded = 0;
+  int total = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSessions();
+  }
+
+  Future<void> _loadSessions() async {
+    final sessions = await LocalSessionStorage.loadAllSessions();
+    final unuploaded = sessions.where((s) => !s.isUploaded).toList();
+
+    setState(() {
+      uploaded = 0;
+      total = unuploaded.length;
+    });
+  }
+
+  void _onUploadPressed() async {
+    // TODDO(prashanth@): UploadService.uploadAll(sessions)
+    for (int i = 0; i < total; i++) {
+      // Simulate upload
+      await Future.delayed(const Duration(milliseconds: 500));
+      setState(() => uploaded++);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final label = total == 0 ? '0/0 files' : '$uploaded/$total';
+
+    return GestureDetector(
+      onTap: total == 0 ? null : _onUploadPressed,
+      child: Column(
+        children: [
+          Stack(
+            alignment: Alignment.center,
+            children: [
+              SizedBox(
+                width: 80,
+                height: 80,
+                child: CircularProgressIndicator(
+                  value: total == 0 ? 1.0 : uploaded / total,
+                  strokeWidth: 6,
+                  backgroundColor: Colors.grey.withOpacity(0.3),
+                  valueColor: const AlwaysStoppedAnimation<Color>(
+                    Colors.yellowAccent,
+                  ),
+                ),
+              ),
+              Text(
+                label,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 12,
+                  fontFamily: 'monospace',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Tap to Upload',
+            style: TextStyle(
+              color: Colors.white70,
+              fontSize: 10,
+              fontFamily: 'monospace',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Previously:

* Ghosts were being cacahed too long.
* In door gps accuracy was causing bouncing of points
* Home screen, upload dial had a different ux

_The problem with GPS accuracy:_ the gps stream returns a reading with an embedded error range. Sometimes this error range is high, eg 20-100m. We were previously ignoring this data. Indoors, it is prudent to only take notice of readings that have a low error range.

This does mean that if the error range is always high, we will need to make a decision. This will manifest as points simply not showing up on screen. We need to look out for this in the field.

A better way to handle this would be some sort of moving average over the points. If the error is consistently high, but the user is moving, we can take an average of the window.

_The problem with ghost caching:_ the ghosts embedded in sites.json shold be refreshed based on the filename. In the old code, there was a bug where we would download the ghost for each site under a predetermined name and use that name to check whether we should re-fetch it.

Now, we save the file locally under the same site/remote_file_name and use this remote_file_name change to determine whether we should re-get it. If the remote_file_name remains the same, we don't bother downloading it (i.e we compare the name in sites.json with the downloaded file).