### PR TITLE
UploadService

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -9,7 +9,6 @@
 
 4. Don't block home screen on prefetching - users in the field must be allowed to run multiple pipelines. Currently we try to re-fetch in home screens init. 
 
-
 5. Auth 
 
 6. First image is without ghost. The how do users set a ghost? Avoid confusion, just don't set one at first. 
@@ -17,6 +16,14 @@
 7. Metrics and consolidated logging 
 
 8. URLs and repeatability: if a session or image is uploaded to some url, and there is an app crash before we can mark the session as uploaded, will the next url created for the same session be different or the same? do we need to garbage collect stray images/sessions in s3? 
+
+9. GPS accuracy: what happens if we don't get an accurate stream in the field? can we detect motion anyway and flag this to the user? see fomonon/pull/11 for details 
+
+10. Marking files as uploaded: currently we just mark local sessions as uploaded instead of deleting them. This is a safeguard. While we will only ever re-upload un-uploaded files, as long as the file exists locally, we can push an app update that re-uploads all of them. While this gives us data safety, it is also a "memory leak". When we decide to GA we should add some scripting that will delete all stale files. 
+
+11. Upload errors: we should flag upload errors as more approachable UI errors. Currently we just log it, we should at least show a snackbar. 
+
+12. Timestamps: we use timestamps in file names to make them unique. Unfortunately this can backfire with clock skew on a phone. 
 
 ### Tech Debt
 

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -15,7 +15,26 @@ The decision to upload sessions separately was made to keep things simple.
 2. Uploads from the phone are atomic and recoverable (i.e recovery means keeping the session files on the phone, and simply re-uploading them)
 3. Merges of all users' session files into one checkpoint/db file can be done via lambda or script
 
-Errors in uploading are managed by simply _not_ writing the "uplaoded" bit so the session manager returns the session the next time around. This is also why we retain the local-path-sessions on disk instead of overwriting it with the modified with-url sessions. 
+Errors in uploading are managed by simply _not_ writing the "uploaded" bit so the session manager returns the session the next time around. This is also why we retain the local-path-sessions on disk instead of overwriting it with the modified with-url sessions. 
+
+
+## Tooling 
+
+Run 
+```
+$ ../hack/s3_bucket.sh --help
+```
+
+To see options. This tool allows you to 
+1. Create a bucket 
+2. Enable/Disable public write on it (for testing) 
+3. Write files to specific paths 
+
+Eg marking a bucket public write 
+```
+$ ./hack/s3_bucket.sh --bucket_name fomomon --public-write false
+$ curl -X PUT --upload-file ./assets/images/loading.png   -H "Content-Type: image/png"   https://fomomon.s3.amazonaws.com/t4gc/loading.png
+```
 
 ## Merging sessions into a db	
 

--- a/examples/prashanth_2025-07-21T15_22_20.440434.json
+++ b/examples/prashanth_2025-07-21T15_22_20.440434.json
@@ -1,0 +1,19 @@
+{
+  "sessionId": "prashanth_2025-07-21T15:22:20.440434",
+  "siteId": "left_6th",
+  "latitude": 12.977215,
+  "longitude": 77.638222,
+  "portraitImagePath": "/data/user/0/com.example.fomomon/app_flutter/images/left_6th/prashanth_2025-07-21_152215_portrait.jpg",
+  "landscapeImagePath": "/data/user/0/com.example.fomomon/app_flutter/images/left_6th/prashanth_2025-07-21_152220_landscape.jpg",
+  "portraitImageUrl": "https://fomomon.s3.amazonaws.com/t4gc/left_6th/prashanth_2025-07-21T15_22_20.440434_portrait.jpg",
+  "landscapeImageUrl": "https://fomomon.s3.amazonaws.com/t4gc/left_6th/prashanth_2025-07-21T15_22_20.440434_landscape.jpg",
+  "responses": [
+    {
+      "questionId": "q2",
+      "answer": "No"
+    }
+  ],
+  "timestamp": "2025-07-21T15:22:20.440434",
+  "isUploaded": false,
+  "userId": "prashanth"
+}

--- a/fomomon/lib/models/captured_session.dart
+++ b/fomomon/lib/models/captured_session.dart
@@ -10,6 +10,8 @@ class CapturedSession {
   final List<SurveyResponse> responses;
   final DateTime timestamp;
   final String userId;
+  String? portraitImageUrl;
+  String? landscapeImageUrl;
   bool isUploaded;
 
   CapturedSession({
@@ -22,6 +24,8 @@ class CapturedSession {
     required this.responses,
     required this.timestamp,
     required this.userId,
+    this.portraitImageUrl = '',
+    this.landscapeImageUrl = '',
     this.isUploaded = false,
   });
 
@@ -32,6 +36,8 @@ class CapturedSession {
     'longitude': longitude,
     'portraitImagePath': portraitImagePath,
     'landscapeImagePath': landscapeImagePath,
+    'portraitImageUrl': portraitImageUrl,
+    'landscapeImageUrl': landscapeImageUrl,
     'responses': responses.map((r) => r.toJson()).toList(),
     'timestamp': timestamp.toIso8601String(),
     'isUploaded': isUploaded,
@@ -46,6 +52,8 @@ class CapturedSession {
       longitude: json['longitude'],
       portraitImagePath: json['portraitImagePath'],
       landscapeImagePath: json['landscapeImagePath'],
+      portraitImageUrl: json['portraitImageUrl'] ?? '',
+      landscapeImageUrl: json['landscapeImageUrl'] ?? '',
       responses:
           (json['responses'] as List)
               .map((r) => SurveyResponse.fromJson(r))

--- a/fomomon/lib/screens/home_screen.dart
+++ b/fomomon/lib/screens/home_screen.dart
@@ -167,6 +167,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 right: 0,
                 child: Center(
                   child: UploadDialWidget(
+                    sites: _sites,
                     // No need to pass anything here, the widget will handle it
                   ),
                 ),

--- a/fomomon/lib/screens/login_screen.dart
+++ b/fomomon/lib/screens/login_screen.dart
@@ -34,6 +34,7 @@ class _LoginScreenState extends State<LoginScreen> {
     final email = _emailController.text.trim();
     final org = _orgController.text.trim();
 
+    // TODO(prashanth@): log the user in.
     if (name.isNotEmpty || email.isNotEmpty && org.isNotEmpty) {
       AppConfig.configure(bucketName: _appName.toLowerCase(), org: org);
 

--- a/fomomon/lib/services/upload_service.dart
+++ b/fomomon/lib/services/upload_service.dart
@@ -1,0 +1,172 @@
+/// upload_service.dart
+/// -------------------
+/// Handles uploading files and JSON to a S3 bucket. Responsibilities:
+/// 1. Map sessions -> S3 bucket paths, eg:
+///   bucketRoot + siteId/userId_timestamp_portrait.jpg
+/// 2. Handle auth/cognito token
+/// 3. Handle retries, rate limiting, etc.
+///
+/// Upload flow for a session:
+/// 1. Upload portrait -> get URL
+/// 2. Upload landscape -> get URL
+/// 3. Upload session JSON
+/// 4. Mark session uploaded
+/// 5. Call onProgress() callback
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/captured_session.dart';
+import '../models/site.dart';
+import '../services/local_session_storage.dart';
+
+class UploadService {
+  // UploadService is a singleton
+  UploadService._privateConstructor();
+  static final UploadService instance = UploadService._privateConstructor();
+
+  // TODO(prashanth@): future auth/cognito token
+  String? idToken;
+
+  // Upload all un-uploaded sessions to the bucketRoot of the matching site.
+  Future<void> uploadAllSessions({
+    required List<Site> sites,
+    required VoidCallback? onProgress,
+  }) async {
+    final sessions = await LocalSessionStorage.loadAllSessions();
+    final unuploaded = sessions.where((s) => !s.isUploaded);
+
+    for (final session in unuploaded) {
+      await _uploadSession(session, sites);
+      // await LocalSessionStorage.markSessionUploaded(session.sessionId);
+      onProgress?.call();
+    }
+  }
+
+  // Upload a single session to the bucketRoot of the matching site.
+  Future<String> _uploadSession(
+    CapturedSession session,
+    List<Site> sites,
+  ) async {
+    final site = sites.firstWhere((s) => s.id == session.siteId);
+    final timestampStr = _sanitizeTimestamp(session.timestamp);
+    final portraitRemotePath =
+        '${site.id}/${session.userId}_${timestampStr}_portrait.jpg';
+    final landscapeRemotePath =
+        '${site.id}/${session.userId}_${timestampStr}_landscape.jpg';
+
+    final portraitUrl = await uploadFile(
+      session.portraitImagePath,
+      site.bucketRoot,
+      portraitRemotePath,
+    );
+
+    final landscapeUrl = await uploadFile(
+      session.landscapeImagePath,
+      site.bucketRoot,
+      landscapeRemotePath,
+    );
+
+    session.portraitImageUrl = portraitUrl;
+    session.landscapeImageUrl = landscapeUrl;
+
+    final sessionJsonPath = 'sessions/${session.userId}_${timestampStr}.json';
+    final sessionUrl = await uploadJson(
+      session.toJson(),
+      site.bucketRoot,
+      sessionJsonPath,
+    );
+    print(
+      'upload_service: Session URL: $sessionUrl, portrait: $portraitUrl, landscape: $landscapeUrl',
+    );
+    return sessionUrl;
+  }
+
+  Future<String> uploadFile(
+    String localPath,
+    String bucketRoot,
+    String remotePath,
+  ) async {
+    final fullUrl = _joinUrls(bucketRoot, remotePath);
+
+    if (idToken == null) {
+      return await _uploadFileNoAuth(localPath, fullUrl);
+    } else {
+      return await _uploadFileNoAuth(localPath, fullUrl);
+    }
+  }
+
+  Future<String> uploadJson(
+    Map<String, dynamic> jsonData,
+    String bucketRoot,
+    String remotePath,
+  ) async {
+    final fullUrl = _joinUrls(bucketRoot, remotePath);
+
+    if (idToken == null) {
+      return await _uploadJsonNoAuth(jsonData, fullUrl);
+    }
+    return await _uploadJsonNoAuth(jsonData, fullUrl);
+  }
+
+  // Internal helper for no-auth file uploads
+  Future<String> _uploadFileNoAuth(String localPath, String fullUrl) async {
+    final file = File(localPath);
+    final bytes = await file.readAsBytes();
+
+    print('upload_service: Uploading file from $localPath to $fullUrl');
+    final response = await http.put(
+      Uri.parse(fullUrl),
+      headers: {'Content-Type': 'application/octet-stream'},
+      body: bytes,
+    );
+
+    if (response.statusCode == 200) {
+      return fullUrl;
+    } else {
+      throw Exception('File upload failed: ${response.statusCode}');
+    }
+  }
+
+  Future<String> _uploadJsonNoAuth(
+    Map<String, dynamic> jsonData,
+    String fullUrl,
+  ) async {
+    final jsonString = jsonEncode(jsonData);
+    final response = await http.put(
+      Uri.parse(fullUrl),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonString,
+    );
+
+    if (response.statusCode == 200) {
+      return fullUrl;
+    } else {
+      throw Exception('JSON upload failed: ${response.statusCode}');
+    }
+  }
+
+  void setToken(String? token) {
+    idToken = token;
+  }
+
+  // Helper method to properly join URLs, handling trailing slashes
+  String _joinUrls(String baseUrl, String path) {
+    // Remove trailing slash from baseUrl if it exists
+    final cleanBase =
+        baseUrl.endsWith('/')
+            ? baseUrl.substring(0, baseUrl.length - 1)
+            : baseUrl;
+    // Remove leading slash from path if it exists
+    final cleanPath = path.startsWith('/') ? path.substring(1) : path;
+    // Join with a single slash
+    return '$cleanBase/$cleanPath';
+  }
+
+  String _sanitizeTimestamp(DateTime timestamp) {
+    return timestamp.toIso8601String().replaceAll(':', '_');
+  }
+}

--- a/fomomon/lib/widgets/upload_dial_widget.dart
+++ b/fomomon/lib/widgets/upload_dial_widget.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import '../services/upload_service.dart';
 import '../services/local_session_storage.dart';
+import '../models/site.dart';
 
 class UploadDialWidget extends StatefulWidget {
-  const UploadDialWidget({super.key});
+  const UploadDialWidget({super.key, required this.sites});
+  final List<Site> sites;
 
   @override
   State<UploadDialWidget> createState() => _UploadDialWidgetState();
@@ -29,12 +32,12 @@ class _UploadDialWidgetState extends State<UploadDialWidget> {
   }
 
   void _onUploadPressed() async {
-    // TODDO(prashanth@): UploadService.uploadAll(sessions)
-    for (int i = 0; i < total; i++) {
-      // Simulate upload
-      await Future.delayed(const Duration(milliseconds: 500));
-      setState(() => uploaded++);
-    }
+    await UploadService.instance.uploadAllSessions(
+      sites: widget.sites,
+      onProgress: () {
+        setState(() => uploaded++);
+      },
+    );
   }
 
   @override


### PR DESCRIPTION
Upload service implementation without the auth. This pr:
1. Uploads files via http PUT
2. Modifies `s3_bucket.sh` to add a `--public-write=true/false` option for testing the http PUT upload
3. Refactors the `upload_dial_widget` to invoke the uploadService
4. Manages the mapping of files -> s3 urls within uploadService
5. Adds a sample session file

No Auth is included here, hence if this pr is to work at all one must first enable public write (see docs/upload.md).