### PR TITLE
Add site implementation

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -8,7 +8,7 @@
 So the issue here is three fold 
 1. If there is good internet - unlikely, as the only case where home screen refresh triggers is when theyre in the field - fetching sites does what we want 
 2. If there is no internet - the current fetch-over-network code will fail, and return the cached sites 
-3. If there is _bad_ internet - the current fetch-over-network code will hang and prevent the user from proceeding
+3. If there is _flaky_ internet - the current fetch-over-network code will hang and prevent the user from proceeding
 
 
 ## Caching 
@@ -18,3 +18,37 @@ Every successful network request automatically caches `sites.json`.
 On fetching sites error, the app reuses the cached sites. 
 The cache directory is `{app_documents}/cache/sites.json`
 
+## Local sites 
+
+We allow the user to create local sites. These sites are stored in a separate `application directory/local_sites.json` file and merged with the cached remote sites during upload time. We need to do this because each session is tagged with a site id, and if no site matches the id, the session is not updated. 
+
+Once the session is uploaded we need to merge the new site back into sites.json so that on next pull, the user sees the new site with a ghost image. 
+
+What will happen if the user re-visits the same site before we merge it back into sites.json? the site should get deduped. Meaning you can re-add the site and it should "upsert" and allow you to capture and upload the session. 
+
+Remote sites get precedence over local ones when there is a conflict deduped on the site id. 
+
+## Site selection flow 
+
+2 main options
+1. Choose existing site 
+2. Create New site 
+
+only one option can be selected at a time, and the continue button is only enabled when a valid selection is made. For the new site: 
+
+1. Current GPS is used 
+2. Copied from "nearest site"
+	- questions
+	- bucket root
+3. Saves this site to local storage
+4. Passes this new site onto the session creation pipeline 
+
+## Where are local sites images uploaded? 
+
+* Path: `{selectedSite.id}/{userId}_{timestamp}_{orientation}.jpg`
+* Bucket: `selectedSite.bucketRoot`
+
+So if a user creates a new local site called `new_site_001`, the images will be uploaded to:
+* `new_site_001/user123_20250115T143000_portrait.jpg`
+* `new_site_001/user123_20250115T143000_landscape.jpg`
+The bucket root comes from the selected/created site, not necessarily the nearest site (though for new local sites, we copy the bucket root from the nearest site).

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -62,7 +62,9 @@ the second org won't contain the location of the recorded data
 	  local phone disk 
 
 
-3. Logging x observability through firebase free tier 
+3. Local sites aren't automatically integrated into `sites.json`. 
+
+4. Logging x observability through firebase free tier 
 
 ### Tech Debt
 

--- a/fomomon/lib/models/site.dart.backup
+++ b/fomomon/lib/models/site.dart.backup
@@ -15,7 +15,6 @@ class Site {
   String? localLandscapePath;
   final String bucketRoot;
   final List<SurveyQuestion> surveyQuestions;
-  final bool isLocalSite;
 
   Site({
     required this.id,
@@ -27,7 +26,6 @@ class Site {
     this.localLandscapePath,
     required this.bucketRoot,
     required this.surveyQuestions,
-    this.isLocalSite = false,
   });
 
   factory Site.fromJson(Map<String, dynamic> json, String bucketRoot) {
@@ -44,27 +42,6 @@ class Site {
           (json['survey'] as List<dynamic>)
               .map((q) => SurveyQuestion.fromJson(q))
               .toList(),
-      isLocalSite: json['is_local_site'] ?? false,
-    );
-  }
-
-  // Factory method for creating local sites
-  factory Site.createLocalSite({
-    required String id,
-    required double lat,
-    required double lng,
-    required String bucketRoot,
-    required List<SurveyQuestion> surveyQuestions,
-  }) {
-    return Site(
-      id: id,
-      lat: lat,
-      lng: lng,
-      referencePortrait: '', // Empty for local sites
-      referenceLandscape: '', // Empty for local sites
-      bucketRoot: bucketRoot,
-      surveyQuestions: surveyQuestions,
-      isLocalSite: true,
     );
   }
 
@@ -80,7 +57,6 @@ class Site {
       'local_landscape_path': localLandscapePath,
       'bucket_root': bucketRoot,
       'survey': surveyQuestions.map((q) => q.toJson()).toList(),
-      'is_local_site': isLocalSite,
     };
   }
 }

--- a/fomomon/lib/screens/home_screen.dart
+++ b/fomomon/lib/screens/home_screen.dart
@@ -16,6 +16,7 @@ import '../screens/capture_screen.dart';
 import 'dart:async';
 import 'dart:ui';
 import '../widgets/upload_dial_widget.dart';
+import '../screens/site_selection_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   final String name;
@@ -238,14 +239,28 @@ class _HomeScreenState extends State<HomeScreen> {
                   child: PlusButton(
                     enabled: _isWithinRange,
                     onPressed: () {
-                      _launchPipeline(
-                        context,
-                        getUserId(widget.name, widget.email, widget.org),
-                        _nearestSite!,
-                        widget.name,
-                        widget.email,
-                        widget.org,
-                      );
+                      if (_isWithinRange && _nearestSite != null) {
+                        // Launch pipeline directly with nearest site
+                        _launchPipeline(
+                          context,
+                          getUserId(widget.name, widget.email, widget.org),
+                          _nearestSite!,
+                          widget.name,
+                          widget.email,
+                          widget.org,
+                        );
+                      } else {
+                        // Launch site selection screen
+                        _launchSiteSelection(
+                          context,
+                          getUserId(widget.name, widget.email, widget.org),
+                          _sites,
+                          _nearestSite,
+                          widget.name,
+                          widget.email,
+                          widget.org,
+                        );
+                      }
                     },
                   ),
                 ),
@@ -274,6 +289,32 @@ void _launchPipeline(
           (_) => CaptureScreen(
             captureMode: 'portrait',
             site: site,
+            userId: userId,
+            name: name,
+            email: email,
+            org: org,
+          ),
+    ),
+  );
+}
+
+// New utility function to launch the site selection screen
+void _launchSiteSelection(
+  BuildContext context,
+  String userId,
+  List<Site> sites,
+  Site? nearestSite,
+  String name,
+  String email,
+  String org,
+) {
+  print("home_screen: launching site selection screen");
+  Navigator.of(context).push(
+    MaterialPageRoute(
+      builder:
+          (context) => SiteSelectionScreen(
+            sites: sites,
+            nearestSite: nearestSite,
             userId: userId,
             name: name,
             email: email,

--- a/fomomon/lib/screens/site_selection_screen.dart
+++ b/fomomon/lib/screens/site_selection_screen.dart
@@ -1,0 +1,293 @@
+/// site_selection_screen.dart
+/// ---------------------------
+/// Screen for selecting an existing site or creating a new local site
+/// when the user is not within range of any existing sites
+
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import '../models/site.dart';
+import '../services/gps_service.dart';
+import '../services/local_site_storage.dart';
+import '../screens/capture_screen.dart';
+
+class SiteSelectionScreen extends StatefulWidget {
+  final List<Site> sites;
+  final Site? nearestSite;
+  final String userId;
+  final String name;
+  final String email;
+  final String org;
+
+  const SiteSelectionScreen({
+    super.key,
+    required this.sites,
+    required this.nearestSite,
+    required this.userId,
+    required this.name,
+    required this.email,
+    required this.org,
+  });
+
+  @override
+  State<SiteSelectionScreen> createState() => _SiteSelectionScreenState();
+}
+
+class _SiteSelectionScreenState extends State<SiteSelectionScreen> {
+  String? _selectedSiteId;
+  final TextEditingController _newSiteController = TextEditingController();
+  bool _isCreatingNewSite = false;
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _newSiteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select Site'),
+        backgroundColor: Colors.blue[900],
+        foregroundColor: Colors.white,
+      ),
+      body: SingleChildScrollView(
+        // Add this wrapper
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Choose how to proceed:',
+              style: Theme.of(
+                context,
+              ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 24),
+
+            // Option A: Choose from existing sites
+            Card(
+              elevation: 4,
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(Icons.location_on, color: Colors.blue[700]),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Choose Existing Site',
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      'Select from sites in your area:',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    DropdownButtonFormField<String>(
+                      value: _selectedSiteId,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        labelText: 'Select Site',
+                      ),
+                      items:
+                          widget.sites
+                              .map(
+                                (site) => DropdownMenuItem(
+                                  value: site.id,
+                                  child: Text(site.id),
+                                ),
+                              )
+                              .toList(),
+                      onChanged: (value) {
+                        setState(() {
+                          _selectedSiteId = value;
+                          _isCreatingNewSite = false;
+                          _newSiteController.clear();
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // Option B: Create new site
+            Card(
+              elevation: 4,
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(Icons.add_location, color: Colors.green[700]),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Create New Site',
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      'Enter a new site ID to create a local site:',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: _newSiteController,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        labelText: 'Site ID',
+                        hintText: 'e.g., new_site_001',
+                      ),
+                      onChanged: (value) {
+                        setState(() {
+                          _isCreatingNewSite = value.trim().isNotEmpty;
+                          if (_isCreatingNewSite) {
+                            _selectedSiteId = null;
+                          }
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 32), // Add some bottom padding
+            // Continue button
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _canProceed() && !_isLoading ? _proceed : null,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.blue[700],
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                child:
+                    _isLoading
+                        ? const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                  Colors.white,
+                                ),
+                              ),
+                            ),
+                            SizedBox(width: 12),
+                            Text('Creating Site...'),
+                          ],
+                        )
+                        : const Text(
+                          'Continue',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  bool _canProceed() {
+    return _selectedSiteId != null || _newSiteController.text.trim().isNotEmpty;
+  }
+
+  void _proceed() async {
+    if (!_canProceed()) return;
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      Site selectedSite;
+
+      if (_isCreatingNewSite) {
+        // Create new local site
+        final newSiteId = _newSiteController.text.trim();
+
+        // Get current GPS position
+        final position = await GpsService.getCurrentPosition();
+
+        // Copy survey questions from nearest site or use empty list
+        final surveyQuestions = widget.nearestSite?.surveyQuestions ?? [];
+
+        // Use bucket root from nearest site or empty string
+        final bucketRoot = widget.nearestSite?.bucketRoot ?? '';
+
+        selectedSite = Site.createLocalSite(
+          id: newSiteId,
+          lat: position.latitude,
+          lng: position.longitude,
+          bucketRoot: bucketRoot,
+          surveyQuestions: surveyQuestions,
+        );
+
+        // Save to local storage
+        await LocalSiteStorage.saveLocalSite(selectedSite);
+
+        print(
+          'Created new local site: $newSiteId at ${position.latitude}, ${position.longitude}',
+        );
+      } else {
+        // Use existing site
+        selectedSite = widget.sites.firstWhere((s) => s.id == _selectedSiteId);
+        print('Selected existing site: ${selectedSite.id}');
+      }
+
+      // Launch pipeline
+      if (mounted) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder:
+                (context) => CaptureScreen(
+                  captureMode: 'portrait',
+                  site: selectedSite,
+                  userId: widget.userId,
+                  name: widget.name,
+                  email: widget.email,
+                  org: widget.org,
+                ),
+          ),
+        );
+      }
+    } catch (e) {
+      print('Error in site selection: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e'), backgroundColor: Colors.red),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+}

--- a/fomomon/lib/services/gps_service.dart
+++ b/fomomon/lib/services/gps_service.dart
@@ -44,6 +44,9 @@ class GpsService {
         ),
       );
     }
+    // On Android, all top options for accuracy are the same, so we can use
+    // high, i.e. best, high and bestForNavigation all map to
+    // PRIORITY_HIGH_ACCURACY.
     return Geolocator.getPositionStream(
       locationSettings: const LocationSettings(accuracy: LocationAccuracy.high),
     );
@@ -56,5 +59,28 @@ class GpsService {
     double lon2,
   ) {
     return Geolocator.distanceBetween(lat1, lon1, lat2, lon2);
+  }
+
+  // Get current position once (used for creating new local sites)
+  static Future<Position> getCurrentPosition() async {
+    if (AppConfig.isTestMode &&
+        AppConfig.mockLat != null &&
+        AppConfig.mockLng != null) {
+      // Return mock position for testing
+      return Position(
+        latitude: AppConfig.mockLat!,
+        longitude: AppConfig.mockLng!,
+        accuracy: 10.0,
+        altitude: 0.0,
+        altitudeAccuracy: 10.0,
+        heading: 0.0,
+        headingAccuracy: 10.0,
+        speed: 0.0,
+        speedAccuracy: 10.0,
+        timestamp: DateTime.now(),
+      );
+    }
+
+    return await Geolocator.getCurrentPosition();
   }
 }

--- a/fomomon/lib/services/local_site_storage.dart
+++ b/fomomon/lib/services/local_site_storage.dart
@@ -1,0 +1,77 @@
+/// local_site_storage.dart
+/// ------------------------
+/// Handles CRUD operations for locally created sites that are stored on device
+/// These sites are created when users are not within range of existing sites
+
+import 'dart:io';
+import 'dart:convert';
+import 'package:path_provider/path_provider.dart';
+import '../models/site.dart';
+
+class LocalSiteStorage {
+  static const String _localSitesFile = 'local_sites.json';
+
+  static Future<void> saveLocalSite(Site site) async {
+    final sites = await loadLocalSites();
+
+    // Check if site already exists and update it, otherwise add new
+    final existingIndex = sites.indexWhere((s) => s.id == site.id);
+    if (existingIndex != -1) {
+      sites[existingIndex] = site;
+    } else {
+      sites.add(site);
+    }
+
+    await _saveLocalSites(sites);
+    print('Saved local site: ${site.id}');
+  }
+
+  static Future<List<Site>> loadLocalSites() async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/$_localSitesFile');
+
+      if (!await file.exists()) {
+        print('No local sites file found');
+        return [];
+      }
+
+      final jsonStr = await file.readAsString();
+      final data = jsonDecode(jsonStr);
+
+      final sites =
+          (data['sites'] as List)
+              .map(
+                (siteJson) => Site.fromJson(siteJson, siteJson['bucket_root']),
+              )
+              .toList();
+
+      print('Loaded ${sites.length} local sites');
+      return sites;
+    } catch (e) {
+      print('Error loading local sites: $e');
+      return [];
+    }
+  }
+
+  static Future<void> _saveLocalSites(List<Site> sites) async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final file = File('${dir.path}/$_localSitesFile');
+
+      final data = {'sites': sites.map((s) => s.toJson()).toList()};
+
+      await file.writeAsString(jsonEncode(data));
+      print('Local sites file updated with ${sites.length} sites');
+    } catch (e) {
+      print('Error saving local sites: $e');
+    }
+  }
+
+  static Future<void> deleteLocalSite(String siteId) async {
+    final sites = await loadLocalSites();
+    sites.removeWhere((site) => site.id == siteId);
+    await _saveLocalSites(sites);
+    print('Deleted local site: $siteId');
+  }
+}


### PR DESCRIPTION
Pressing the plus button when no site is close triggers a "choice" screen
1. Pick an existing site
2. Add a new site

Here is an example flow:
1. User isn't close to a site.
2. User hits plus button.
3. User is thrown into `choosing an existing site or creating a new site` flow
4. If they choose a new site, they need to name it, and it adopts the current gps
5. If a local site with that name exists, that site is updated with the gps
6. That site is then passed into the pipeline, and the images captured are uploaded to the bucket root (see `docs/sites.md` for details)
7. Now when the user goes to home screen, we fetch (if there is network) and merge remote and local sites, thus finding this site. The merge happens even when there is no network.
8. At upload time this matches the `site.id` on the session
9. However if in the choice page, the user selects an existing site, that site is passed into the pipeline flow, regardless if it's a remote or just created local site
10. If a site exists in the remote sites list as well as the local sites list, the remote site gets precedence