### PR TITLE
Fix GPS acquisition / upload race

### DIFF
--- a/fomomon/lib/config/app_config.dart
+++ b/fomomon/lib/config/app_config.dart
@@ -17,6 +17,10 @@ class AppConfig {
   static const String guestEmail = 'srini@ncf-india.org';
   static const String guestOrg = 'ncf';
 
+  // Default bucket for guest mode when no sites are available
+  static const String guestBucket =
+      'https://fomomonguest.s3.ap-south-1.amazonaws.com/';
+
   // Organization data mapping org codes to default values
   static const Map<String, Map<String, String>> organizationData = {
     't4gc': {'email': 'prashanth@tech4goodcommunity.com', 'name': 'Prashanth'},

--- a/fomomon/pubspec.yaml
+++ b/fomomon/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+4
+version: 1.0.2+5
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
There was a race condition where we couldn't detect any nearby sites, and hence we failed to set the bucket root on the new sites json. The symptom of this bug is that the site will how up in the add site flow without any questions. While this is OK in the sense that we will not always have a "nearby site" from which to copy info (even when there is a gps, because this might be the very first site being added on the app) - we should have a reliable fallback option. We should never be in a situation where there is a site, but no home for that site's data in the backend.

This PR fixes the issue by having a resolution of fallback options for malformed sites:
1. Look at the first site's bucket root
2. If there is no other site, user the default fomogues bucket