### PR TITLE
"Start here" documentation

### DIFF
--- a/docs/start-here/README.md
+++ b/docs/start-here/README.md
@@ -1,0 +1,10 @@
+# Start Here
+
+Use the overview docs as the stable entry point into the repo:
+
+- [Overview Index](./overview/index.md)
+- [Architecture](./overview/architecture.md)
+- [Users And Journeys](./overview/users.md)
+- [Engineering Guide](./overview/engineering.md)
+
+These docs summarize the current system shape. For deeper design discussion and areas still in flux, continue into `docs/v2/`.

--- a/docs/start-here/overview/architecture.md
+++ b/docs/start-here/overview/architecture.md
@@ -1,0 +1,84 @@
+# Architecture
+
+## High-level shape
+
+Fomomon has three important UI and code concepts:
+
+- **Screens**: route-level steps such as login, site prefetch, home, capture, confirm, survey, and upload queue.
+- **Widgets**: reusable UI pieces inside screens such as the plus button, upload dial, orientation dial, site map, and session dialogs.
+- **Services**: non-UI logic for auth, site fetching, local storage, uploads, telemetry, and sync.
+
+A screen is made up of widgets. The app's main user action is a pipeline of screens triggered from the plus button on the home screen.
+
+See also: [docs/code.md](../../code.md)
+
+## Capture pipeline
+
+The primary pipeline starts when the field user taps the plus button:
+
+1. Home screen: decides whether the user can continue with the nearest site or should choose/create a site.
+2. Site selection: screen optionally creates a local site if the user is not using an existing one.
+3. Capture screen: records the portrait image.
+4. Confirm screen: either accepts or retakes the portrait image.
+5. Capture screen: records the landscape image.
+6. Confirm screen: either accepts or retakes the landscape image.
+7. Survey screen: collects responses when the site has survey questions.
+8. The app saves a local session package for later upload.
+
+This is why the app feels like a guided workflow rather than a collection of independent pages.
+
+See also: [docs/ghost_images.md](../../ghost_images.md) and [docs/surveys.md](../../surveys.md)
+
+## Data flow
+
+The current architecture is direct-to-AWS:
+
+- Login goes from the app to Cognito.
+- Authenticated upload uses temporary Cognito-backed AWS credentials and presigned S3 PUT URLs.
+- Site configuration and ghost images are read from S3 and cached locally.
+- Session files are assembled on device first, then uploaded to S3.
+
+There is **no app API server** in the current runtime path.
+
+See also: [docs/v2/background.md](../../v2/background.md), [docs/auth.md](../../auth.md), and [docs/upload.md](../../upload.md)
+
+## Source-of-truth rules
+
+Today the system uses different writers for different kinds of data:
+
+- `sites.json` is updated from both the app and the admin interface.
+- Ghost images are updated through the admin interface.
+- New users and new orgs are updated through the admin interface.
+- Sessions are created and updated through the app.
+
+In other words, Fomomon coordinates a shared file-based system, not a database-backed transaction system.
+
+See also: [docs/v2/admin.md](../../v2/admin.md) and [docs/v2/sync_sites.md](../../v2/sync_sites.md)
+
+## Local-first behavior
+
+The field app is built to keep working when connectivity is weak:
+
+- `sites.json` is downloaded from S3 and cached locally.
+- ghost images are downloaded from S3 and cached locally
+- locally created sites are stored separately on device
+- captured sessions are stored locally until uploaded
+
+After upload, local sites may be promoted into remote `sites.json`, using uploaded session images as the new reference images for that site.
+
+See also: [docs/sites.md](../../sites.md) and [docs/ghost_images.md](../../ghost_images.md)
+
+## Main code entry points
+
+- Screens: [fomomon/lib/screens](../../../fomomon/lib/screens)
+- Widgets: [fomomon/lib/widgets](../../../fomomon/lib/widgets)
+- Services: [fomomon/lib/services](../../../fomomon/lib/services)
+- Admin app: [admin](../../../admin)
+
+Also see [docs/code.md](../../code.md)
+
+## Further detail
+
+- [docs/v2/background.md](../../v2/background.md)
+- [docs/v2/sync_sites.md](../../v2/sync_sites.md)
+- [docs/v2/api_server.md](../../v2/api_server.md)

--- a/docs/start-here/overview/engineering.md
+++ b/docs/start-here/overview/engineering.md
@@ -1,0 +1,93 @@
+# Engineering Guide
+
+This is the short engineering map for how the current app works.
+
+## Key files in S3 and on device
+
+Important shared files:
+
+- `auth_config.json`: public bootstrap config for Cognito details
+- `{org}/sites.json`: canonical remote site list for an org
+- `{org}/{siteId}/...jpg`: ghost images and captured images
+- `{org}/sessions/*.json`: uploaded session metadata
+
+Important local caches and stores:
+
+- cached `sites.json`
+- cached ghost images
+- local site store for sites created on device
+- local session store for sessions waiting to upload
+
+See also: [docs/sites.md](../../sites.md) and [docs/ghost_images.md](../../ghost_images.md)
+
+## Read and write responsibilities
+
+Current write ownership is split:
+
+- The app reads `auth_config.json`, `sites.json`, and ghost images.
+- The app writes session images, session JSON, and can update `sites.json` by promoting local sites after upload.
+- The admin interface writes users, org setup, `sites.json`, and ghost images.
+
+Because both the app and admin can write `sites.json`, this is a file-coordination design with eventual consistency and some write-conflict risk (see [issues/50](https://github.com/bprashanth/fomomon/issues/50)). 
+
+See also: [docs/v2/sync_sites.md](../../v2/sync_sites.md) and [docs/v2/admin.md](../../v2/admin.md)
+
+## Screen map
+
+Core screens in [fomomon/lib/screens](../../../fomomon/lib/screens):
+
+- `login_screen.dart`: fetches auth config and starts login
+- `site_prefetch_screen.dart`: fetches `sites.json` and ghost images for offline use after login
+- `home_screen.dart`: shows nearby sites and the plus-button entry point
+- `site_selection_screen.dart`: choose an existing site or create a local one
+- `capture_screen.dart`: camera capture with ghost-image guidance
+- `confirm_screen.dart`: retake or accept each capture
+- `survey_screen.dart`: optional survey completion
+- `upload_queue_screen.dart`: review and upload pending sessions
+
+See also: [docs/ux/ux.md](../../ux/ux.md), [docs/ux/finding_sites.md](../../ux/finding_sites.md), and [docs/ux/upload_queue.md](../../ux/upload_queue.md)
+
+## Widget map
+
+Important widgets in [fomomon/lib/widgets](../../../fomomon/lib/widgets):
+
+- `plus_button.dart`: starts the capture pipeline
+- `upload_dial_widget.dart`: drives upload and post-upload sync
+- `site_map_widget.dart`: renders site and user position context
+- `orientation_dial.dart`: helps align capture orientation
+- `session_detail_dialog.dart`: inspects queued sessions
+
+## Service map
+
+Important services in [fomomon/lib/services](../../../fomomon/lib/services):
+
+- `auth_service.dart`: Cognito login, token refresh, and AWS credentials
+- `site_service.dart`: fetch `sites.json`, download ghost images, cache locally, merge local sites
+- `upload_service.dart`: upload images and session JSON to S3
+- `site_sync_service.dart`: promote locally created sites into remote `sites.json`
+- `fetch_service.dart`: signed and unsigned HTTP fetches
+- `local_session_storage*.dart`: persist sessions on device
+- `local_site_storage*.dart`: persist field-created local sites on device
+- `local_image_storage*.dart`: persist captured and ghost images locally
+
+See also: [docs/auth.md](../../auth.md), [docs/upload.md](../../upload.md), and [docs/sites.md](../../sites.md)
+
+## Functionality map
+
+If you are tracing a feature, start here:
+
+- login: `login_screen.dart` -> `auth_service.dart`
+- initial site fetch: `site_prefetch_screen.dart` -> `site_service.dart`
+- home-screen refresh: `home_screen.dart` -> `site_service.dart`
+- capture pipeline: `home_screen.dart` / `plus_button.dart` -> capture/confirm/survey screens
+- upload: `upload_queue_screen.dart` / `upload_dial_widget.dart` -> `upload_service.dart`
+- local-site promotion after upload: `upload_dial_widget.dart` -> `site_sync_service.dart`
+- admin org/user/site maintenance: [admin/backend](../../../admin/backend) and [admin/frontend](../../../admin/frontend)
+
+## Further detail
+
+- [docs/v2/background.md](../../v2/background.md)
+- [docs/v2/sync_sites.md](../../v2/sync_sites.md)
+- [docs/upload.md](../../upload.md)
+- [docs/sites.md](../../sites.md)
+- [docs/ghost_images.md](../../ghost_images.md)

--- a/docs/start-here/overview/index.md
+++ b/docs/start-here/overview/index.md
@@ -1,0 +1,76 @@
+# Fomomon 
+
+## What is photo monitoring? 
+
+Here is a great [doc](https://research.fs.usda.gov/download/treesearch/3255.pdf) on fixed point photomonitoring in ecology. An excerpt from the document
+```
+A simple question might deal with effects of livestock grazing on a riparian
+area: (1) Are streambanks being broken down?  (2) Are riparian shrubs able to
+grow in both height and crown spread? (3) Is there enough herbage remaining
+after grazing to trap sediments from flooding? (4) Is herbaceous vegetation
+stable, improving, or deteriorating?  
+
+These questions require selection of a sampling location, placement of enough
+photo points to answer each of the four questions, and establishment of camera
+locations to adequately photograph each photo point. Try to select camera
+locations that will photograph more than one photo point. Next, time or times
+of year to do the photography must be specified, such as just prior to animal
+use of the area, just after they leave, or fall vegetation conditions. Will a
+riparian site be monitored for high spring runoff? late season low flows? or
+during floods? Monitoring of stream flows vs. animal use probably will require
+different scheduling.
+```
+
+The fomomon app helps establish it as a practice. 
+
+## Overview
+
+There are two main personas who will use the system
+
+- Field staff: they execute the monitoring (e.g. go to this location, take a picture) 
+- Program admins: they plan the monitoring (e.g. set the date, time, location, frequency for monitoring)
+
+There is a third persona, the ecologist who plans an experiment and analyzes the results. Supporting this persona is out of scope for Fomomon (but in scope for good-shepherd).  
+
+Fomomon has two main surfaces, for each persona.
+
+## What the app does
+
+The app exists to tie together the following pieces:
+
+1. Sites: fixed points on the earth. The app helps record and guide field staff to them. 
+2. Ghost images: a visual reference of the site so the field staff can capture the same image over time. 
+3. Pipeline of activities: since the field staff is often not well versed with the end goal of monitoring, the app helps them take the required landscape/portrait images, at the right orientation/bearing/heading, and answer a few pre-configured questions. 
+
+The output is a package of files written into the right S3 directories for the right organization.
+
+## Current architecture
+
+The system is currently serverless from the field app's point of view:
+
+- There is **no API server** in the current app architecture.
+- The app talks directly to Cognito for login.
+- The app talks directly to S3 for reading configuration and writing uploads.
+- The admin interface uses AWS credentials on the server side to update Cognito and S3.
+
+That means some files are shared coordination points:
+
+- `auth_config.json`
+- `{org}/sites.json`
+- ghost image files under site directories
+- session JSON files under `sessions/`
+
+## Read next
+
+- [Architecture](./architecture.md)
+- [Users And Journeys](./users.md)
+- [Engineering Guide](./engineering.md)
+
+## Further detail
+
+These deeper docs are useful after this overview:
+
+- [docs/v2/background.md](../../v2/background.md)
+- [docs/v2/admin.md](../../v2/admin.md)
+- [docs/v2/sync_sites.md](../../v2/sync_sites.md)
+- [docs/v2/api_server.md](../../v2/api_server.md)

--- a/docs/start-here/overview/users.md
+++ b/docs/start-here/overview/users.md
@@ -1,0 +1,89 @@
+# Users And Journeys
+
+Fomomon has two main user journeys: the field user journey and the admin user journey.
+Within the admin journeys, there is: 
+1. A system-admin, i.e. someone who has deployed the app for a set of orgs
+2. A program admin, i.e. someone who has thought strategically about site placement, ghost images and survey questions. 
+
+In the case of the main Fomomon deployment, T4GC plays the role of system admin, while the ecologist running an experiment plays the role of aprogram admin. 
+
+## Field user
+
+The field user's job is to create and upload photo monitoring sessions.
+
+Typical actions:
+
+- log in with credentials issued ahead of time
+- fetch `sites.json` and ghost images for offline use (this happens automatically on login)
+- choose an existing site or create a new local site
+- capture portrait and landscape images
+- answer surveys when present
+- upload sessions 
+
+See also: [docs/auth.md](../../auth.md), [docs/sites.md](../../sites.md), [docs/ghost_images.md](../../ghost_images.md), and [docs/upload.md](../../upload.md)
+
+### Field user prerequisites
+
+- Their organization mmust already be on-boarded by the system admin. 
+- They themselves must be onboarded by the program admin. This is how they obtain login credentials.
+- Their device must be able to cache site data and ghost images locally.
+- In practice they also need camera and location permissions.
+
+### Field user outputs
+
+The field app is the only place that creates session data:
+
+- uploaded images under site-specific storage paths
+- uploaded session JSON under `sessions/`
+- site additions promoted back into `sites.json`
+
+See also: [docs/upload.md](../../upload.md) and [docs/v2/sync_sites.md](../../v2/sync_sites.md)
+
+## Admin user
+
+Currently, both the system and program admin roles are merged in one and operated via a single admin interface. The only people using this interface are the T4GC eng team. 
+
+### System admin 
+
+First, the system admin (this could be someone at T4GC but also eg an NCF wide admin who has deployed the entire stack on-prem) must create an "org". This "org" admin then owns the canonical setup for:
+
+- bucket and auth configuration
+- AWS CLI credentials or equivalent AWS credentials made available to the program admin
+- permission to operate on the Fomomon S3 bucket
+- permission to manage Cognito app resources
+- permission to manage the IAM role used by the phone app
+
+Currently this role is owned by the T4GC eng team, and there are no plans to transition it to the community. 
+
+### System admin: AWS permission categories
+
+At a minimum, the admin path needs access equivalent to:
+
+- `s3:ListBucket`, `s3:GetObject`, `s3:PutObject`, and delete permissions for org files such as `sites.json`, `users.json`, ghost images, and telemetry cleanup
+- Cognito user-pool administration for creating users, deleting users, listing users, and resetting passwords
+- Cognito identity-pool read/update access for wiring app auth
+- IAM role read/update access for the phone app role policy
+- enough bucket-level access to inspect or enforce bucket configuration used by the admin tooling
+
+### Program admin
+
+The program admin user's job is to keep organizations, users, sites, and ghost images coherent.
+
+Typical actions:
+
+- create users and reset passwords
+- add or remove sites in `sites.json`
+- rename or delete sites
+- upload or replace ghost images
+
+See also: [docs/v2/admin.md](../../v2/admin.md), [admin/README.md](../../../admin/README.md), and [admin/AUTH.md](../../../admin/AUTH.md)
+
+Currently this role is owned by the T4GC eng team, but it will be transitioned to individual Ecologists running their programs. To do so, the admin interface needs to function without relying on local AWS credentials - i.e. the functionality of the admin server needs to merge with an API server in the cloud that is capable of using its own credentials (or those of a logged in cognito user) to perform the actions above.  
+
+## Further detail
+
+- [docs/v2/admin.md](../../v2/admin.md)
+- [docs/v2/background.md](../../v2/background.md)
+- [docs/auth.md](../../auth.md)
+- [admin/README.md](../../../admin/README.md)
+- [admin/AUTH.md](../../../admin/AUTH.md)


### PR DESCRIPTION
Adds an overview dir, which summarizes current app operations and ideologies. Links into prior relevant docs. The idea is to start from `start-here`, and follow in the sequence of its README.